### PR TITLE
Postgres bulk insert 対応

### DIFF
--- a/app/interfaces/api/user/UserApiController.scala
+++ b/app/interfaces/api/user/UserApiController.scala
@@ -1,6 +1,7 @@
 package interfaces.api.user
 
-import dev.tchiba.sdmt.core.user.{UserId, UserRepository}
+import dev.tchiba.sdmt.core.user.{User, UserId, UserRepository}
+import dev.tchiba.sub.email.EmailAddress
 import interfaces.api.user.json.UserResponse
 import interfaces.json.CollectionResponse
 import interfaces.json.error.ErrorResults
@@ -29,5 +30,20 @@ final class UserApiController @Inject() (cc: ControllerComponents, userRepositor
         )
       case Some(user) => Ok(UserResponse(user).json)
     }
+  }
+
+  // bulkInsertのテスト用
+  def bulkInsert(): Action[AnyContent] = Action {
+    val users = (1 to 10).map(createUser)
+    userRepository.batchInset(users)
+    NoContent
+  }
+
+  private def createUser(i: Int) = {
+    User.create(
+      name = s"User$i",
+      email = EmailAddress(s"use$i@gmail.com"),
+      avatarUrl = None
+    )
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,6 +45,8 @@ play {
 db {
   default {
     driver = org.postgresql.Driver
+    # https://jdbc.postgresql.org/documentation/94/connect.html
+    # reWriteBatchedInserts=true でPostgres側で最適化してくれる。ScalikeJdbcが出力するログには反映されない
     url = "jdbc:postgresql://"${?DB_HOST}":5432/sdmt?reWriteBatchedInserts=true"
     username = ${?DB_USER}
     password = ${?DB_PASSWORD}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,7 +45,7 @@ play {
 db {
   default {
     driver = org.postgresql.Driver
-    url = "jdbc:postgresql://"${?DB_HOST}":5432/sdmt"
+    url = "jdbc:postgresql://"${?DB_HOST}":5432/sdmt?reWriteBatchedInserts=true"
     username = ${?DB_USER}
     password = ${?DB_PASSWORD}
   }

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@ POST        /api/sign-in                                                        
 POST        /api/sign-out                                                              interfaces.api.auth.signOut.SignOutController.action()
 
 GET         /api/users                                                                 interfaces.api.user.UserApiController.allUsers()
+POST        /api/users/bulk                                                            interfaces.api.user.UserApiController.bulkInsert()
 GET         /api/users/:userId                                                         interfaces.api.user.UserApiController.findUser(userId: String)
 
 GET         /api/bounded-contexts                                                      interfaces.api.boundedContext.list.ListBoundedContextsApiController.action()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,12 @@ services:
   postgres:
     image: postgres:13.4
     container_name: postgresdb
+    # Make postgres logs. More information about logging, see official documentation: https://www.postgresql.org/docs/11/runtime-config-logging.html
+    command: postgres -c log_destination=stderr -c log_statement=all -c log_connections=on -c log_disconnections=on
+    logging:
+      options:
+        max-size: "10k"
+        max-file: "5"
     ports:
       - "5432:5432"
     environment:

--- a/sdmt-core/src/main/scala/dev/tchiba/sdmt/core/user/UserRepository.scala
+++ b/sdmt-core/src/main/scala/dev/tchiba/sdmt/core/user/UserRepository.scala
@@ -13,4 +13,6 @@ trait UserRepository extends Repository[User] {
   def update(user: User): Unit
 
   def delete(user: User): Unit
+
+  def batchInset(users: Seq[User]): Unit
 }


### PR DESCRIPTION
## 概要

何もしない状態で、ScalikeJdbc generator が生成した #batchInsert を使うと、リストの要素数分 `insert` 文が走る。

```
2022-09-05 16:15:16.130 UTC [78] LOG:  execute S_1: BEGIN
2022-09-05 16:15:16.136 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.136 UTC [78] DETAIL:  parameters: $1 = '8423b9fd-1d41-488f-bf0c-62742769eda3', $2 = 'User1', $3 = 'use1@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101572', $6 = '2022-09-06 01:15:16.101586'
2022-09-05 16:15:16.136 UTC [78] DETAIL:  parameters: $1 = '8423b9fd-1d41-488f-bf0c-62742769eda3', $2 = 'User1', $3 = 'use1@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101572', $6 = '2022-09-06 01:15:16.101586'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '70eea8b4-863e-4a3e-b068-0ee08e534ad1', $2 = 'User2', $3 = 'use2@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101595', $6 = '2022-09-06 01:15:16.101597'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '6322d7d6-8f3c-4d81-a937-0a37cac2603e', $2 = 'User3', $3 = 'use3@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101599', $6 = '2022-09-06 01:15:16.101601'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '6d4e36f3-f8cf-4716-80cb-3554b887d6f1', $2 = 'User4', $3 = 'use4@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101603', $6 = '2022-09-06 01:15:16.101605'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '9cf62589-07f0-424e-8814-3c014f77bffc', $2 = 'User5', $3 = 'use5@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101607', $6 = '2022-09-06 01:15:16.101618'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '4f2ace25-ba12-4add-ace2-c009e0226257', $2 = 'User6', $3 = 'use6@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101621', $6 = '2022-09-06 01:15:16.101622'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = '695b8527-662c-4dee-a0e8-f94d676bb83b', $2 = 'User7', $3 = 'use7@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101625', $6 = '2022-09-06 01:15:16.101626'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = 'a94c5a61-3e27-4bf2-bff9-ebf6d6f29a77', $2 = 'User8', $3 = 'use8@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101628', $6 = '2022-09-06 01:15:16.10163'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = 'e427cb29-e9eb-417b-b231-b5734381d4d0', $2 = 'User9', $3 = 'use9@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101632', $6 = '2022-09-06 01:15:16.101634'
2022-09-05 16:15:16.137 UTC [78] LOG:  execute S_2: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 )
2022-09-05 16:15:16.137 UTC [78] DETAIL:  parameters: $1 = 'a6e0505f-2037-459f-863d-0257dc6b947b', $2 = 'User10', $3 = 'use10@gmail.com', $4 = NULL, $5 = '2022-09-06 01:15:16.101636', $6 = '2022-09-06 01:15:16.101637'
2022-09-05 16:15:16.151 UTC [78] LOG:  execute S_3: COMMIT
2022-09-05 16:15:32.808 UTC [78] LOG:  disconnection: session time: 0:00:16.756 user=root database=sdmt host=172.18.0.1 port=59112
```

しかし、urlに `?reWriteBatchedInserts=true`を付与して実行すると、下記のように bulkInsertになることが分かった。

```
2022-09-05 16:16:13.348 UTC [81] LOG:  execute <unnamed>: BEGIN
2022-09-05 16:16:13.349 UTC [81] LOG:  execute <unnamed>: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 ),( $7, $8, $9, $10, $11, $12 ),( $13, $14, $15, $16, $17, $18 ),( $19, $20, $21, $22, $23, $24 ),( $25, $26, $27, $28, $29, $30 ),( $31, $32, $33, $34, $35, $36 ),( $37, $38, $39, $40, $41, $42 ),( $43, $44, $45, $46, $47, $48 )
2022-09-05 16:16:13.349 UTC [81] DETAIL:  parameters: $1 = '7d6f9f04-56fe-4c5e-b197-d0ee1313319f', $2 = 'User1', $3 = 'use1@gmail.com', $4 = NULL, $5 = '2022-09-06 01:16:13.321383', $6 = '2022-09-06 01:16:13.321407', $7 = '98058a44-14ac-4b3c-a6ce-1af5fd85f889', $8 = 'User2', $9 = 'use2@gmail.com', $10 = NULL, $11 = '2022-09-06 01:16:13.321417', $12 = '2022-09-06 01:16:13.321419', $13 = '62a85b92-52b1-4162-a77e-85bb8b138b07', $14 = 'User3', $15 = 'use3@gmail.com', $16 = NULL, $17 = '2022-09-06 01:16:13.321422', $18 = '2022-09-06 01:16:13.321423', $19 = '8a15cac7-4e67-423d-a7d8-cf1400c5b886', $20 = 'User4', $21 = 'use4@gmail.com', $22 = NULL, $23 = '2022-09-06 01:16:13.321426', $24 = '2022-09-06 01:16:13.321427', $25 = '7e6bab07-47fe-43c5-85fb-3e56150776f5', $26 = 'User5', $27 = 'use5@gmail.com', $28 = NULL, $29 = '2022-09-06 01:16:13.32143', $30 = '2022-09-06 01:16:13.321431', $31 = '658fa448-bdb2-4cf1-bdd4-78b96e59d17f', $32 = 'User6', $33 = 'use6@gmail.com', $34 = NULL, $35 = '2022-09-06 01:16:13.321433', $36 = '2022-09-06 01:16:13.321444', $37 = '2b5ac9a5-f355-4051-9dd1-1afd59f2cec7', $38 = 'User7', $39 = 'use7@gmail.com', $40 = NULL, $41 = '2022-09-06 01:16:13.321447', $42 = '2022-09-06 01:16:13.321448', $43 = '50264b3a-da8f-4969-9c84-837da6232a47', $44 = 'User8', $45 = 'use8@gmail.com', $46 = NULL, $47 = '2022-09-06 01:16:13.32145', $48 = '2022-09-06 01:16:13.321452'
2022-09-05 16:16:13.349 UTC [81] LOG:  execute <unnamed>: insert into users( user_id, user_name, email_address, avatar_url, created_at, updated_at ) values ( $1, $2, $3, $4, $5, $6 ),( $7, $8, $9, $10, $11, $12 )
2022-09-05 16:16:13.349 UTC [81] DETAIL:  parameters: $1 = '73bcc88e-017e-4e28-9548-7efc703d44c1', $2 = 'User9', $3 = 'use9@gmail.com', $4 = NULL, $5 = '2022-09-06 01:16:13.321454', $6 = '2022-09-06 01:16:13.321456', $7 = 'e7d3db21-a44d-48ed-bc0c-521b6c30ed54', $8 = 'User10', $9 = 'use10@gmail.com', $10 = NULL, $11 = '2022-09-06 01:16:13.321458', $12 = '2022-09-06 01:16:13.321459'
2022-09-05 16:16:13.361 UTC [81] LOG:  execute S_1: COMMIT
```

## 注意点

ScalikeJDBCが出力するログは変わらず、複数回 insert 文だが、Postgres側はオプションをつければちゃんと最適化されて multiple inserts になっている。
Postgres側のログを出力して確認しないと違いは見れない。