### PR TITLE
Feature/151 apply user action all api

### DIFF
--- a/app/interfaces/api/auth/signOut/SignOutController.scala
+++ b/app/interfaces/api/auth/signOut/SignOutController.scala
@@ -2,17 +2,19 @@ package interfaces.api.auth.signOut
 
 import dev.tchiba.auth.usecase.signOut.{SignOutInput, SignOutOutput, SignOutUseCase}
 import interfaces.api.auth.AccessTokenCookieHelper
+import interfaces.security.UserAction
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
 
 final class SignOutController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     signOutUseCase: SignOutUseCase
 ) extends AbstractController(cc)
     with AccessTokenCookieHelper {
 
-  def action(): Action[AnyContent] = Action { implicit request =>
+  def action(): Action[AnyContent] = userAction { implicit request =>
     getAccessToken(request) match {
       case None => NoContent
       case Some(token) =>

--- a/app/interfaces/api/boundedContext/create/CreateBoundedContextApiController.scala
+++ b/app/interfaces/api/boundedContext/create/CreateBoundedContextApiController.scala
@@ -7,6 +7,7 @@ import dev.tchiba.sdmt.usecase.boundedContext.create.{
 }
 import interfaces.api.SdmtApiController
 import interfaces.api.boundedContext.json.BoundedContextResponse
+import interfaces.security.UserAction
 import play.api.mvc.{Action, ControllerComponents}
 
 import javax.inject.Inject
@@ -14,11 +15,12 @@ import scala.concurrent.ExecutionContext
 
 final class CreateBoundedContextApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     createBoundedContextUseCase: CreateBoundedContextUseCase
 )(implicit ec: ExecutionContext)
     extends SdmtApiController(cc) {
 
-  def action(): Action[CreateBoundedContextRequest] = Action(CreateBoundedContextRequest.validateJson) {
+  def action(): Action[CreateBoundedContextRequest] = userAction(CreateBoundedContextRequest.validateJson) {
     implicit request =>
       val name     = request.body.get.name
       val alias    = request.body.get.alias

--- a/app/interfaces/api/boundedContext/create/CreateBoundedContextRequest.scala
+++ b/app/interfaces/api/boundedContext/create/CreateBoundedContextRequest.scala
@@ -1,6 +1,6 @@
 package interfaces.api.boundedContext.create
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.ValidatedNel
 import dev.tchiba.sdmt.core.boundedContext.{BoundedContextAlias, BoundedContextName, BoundedContextOverview}
 import interfaces.json.request.play.{PlayJsonRequest, PlayJsonRequestCompanion}
 import play.api.libs.json.{Json, OFormat}

--- a/app/interfaces/api/boundedContext/delete/DeleteBoundedContextApiController.scala
+++ b/app/interfaces/api/boundedContext/delete/DeleteBoundedContextApiController.scala
@@ -3,16 +3,17 @@ package interfaces.api.boundedContext.delete
 import dev.tchiba.sdmt.core.boundedContext.BoundedContextId
 import dev.tchiba.sdmt.usecase.boundedContext.delete.{DeleteBoundedContextInput, DeleteBoundedContextUseCase}
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
 
 final class DeleteBoundedContextApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     deleteBoundedContextUseCase: DeleteBoundedContextUseCase
 ) extends SdmtApiController(cc) {
-
-  def action(boundedContextId: String): Action[AnyContent] = Action {
+  def action(boundedContextId: String): Action[AnyContent] = userAction {
     QueryValidator.sync {
       BoundedContextId.validate(boundedContextId)
     } { boundedContextId =>

--- a/app/interfaces/api/boundedContext/find/FindBoundedContextApiController.scala
+++ b/app/interfaces/api/boundedContext/find/FindBoundedContextApiController.scala
@@ -3,12 +3,14 @@ package interfaces.api.boundedContext.find
 import dev.tchiba.sdmt.core.boundedContext.{BoundedContextAlias, BoundedContextId, BoundedContextRepository}
 import interfaces.api.boundedContext.json.BoundedContextResponse
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
 
 class FindBoundedContextApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     boundedContextRepository: BoundedContextRepository
 ) extends SdmtApiController(cc) {
 
@@ -18,7 +20,7 @@ class FindBoundedContextApiController @Inject() (
    * @param idOrAlias IDもしくはエイリアスの文字列
    * @return
    */
-  def action(idOrAlias: String): Action[AnyContent] = Action {
+  def action(idOrAlias: String): Action[AnyContent] = userAction {
     QueryValidator.sync {
       validateIdOrAlias(idOrAlias)
     } { validatedIdOrAlias =>

--- a/app/interfaces/api/boundedContext/update/UpdateBoundedContextApiController.scala
+++ b/app/interfaces/api/boundedContext/update/UpdateBoundedContextApiController.scala
@@ -4,6 +4,7 @@ import dev.tchiba.sdmt.core.boundedContext.BoundedContextId
 import dev.tchiba.sdmt.usecase.boundedContext.update.{UpdateBoundedContextOutput, UpdateBoundedContextUseCase}
 import interfaces.api.boundedContext.json.BoundedContextResponse
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, ControllerComponents}
 
 import javax.inject.Inject
@@ -11,12 +12,13 @@ import scala.concurrent.ExecutionContext
 
 class UpdateBoundedContextApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     updateBoundedContextUseCase: UpdateBoundedContextUseCase
 )(implicit ec: ExecutionContext)
     extends SdmtApiController(cc) {
 
-  def action(targetId: String): Action[UpdateBoundedContextRequest] = Action(UpdateBoundedContextRequest.validateJson) {
-    implicit request =>
+  def action(targetId: String): Action[UpdateBoundedContextRequest] =
+    userAction(UpdateBoundedContextRequest.validateJson) { implicit request =>
       QueryValidator.sync {
         BoundedContextId.validate(targetId)
       } { boundedContextId =>
@@ -35,5 +37,5 @@ class UpdateBoundedContextApiController @Inject() (
             )
         }
       }
-  }
+    }
 }

--- a/app/interfaces/api/domainmodel/delete/DeleteDomainModelApiController.scala
+++ b/app/interfaces/api/domainmodel/delete/DeleteDomainModelApiController.scala
@@ -2,6 +2,7 @@ package interfaces.api.domainmodel.delete
 
 import dev.tchiba.sdmt.core.domainmodel.{DomainModelId, DomainModelRepository}
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
@@ -9,6 +10,7 @@ import scala.annotation.unused
 
 class DeleteDomainModelApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     domainModelRepository: DomainModelRepository
 ) extends SdmtApiController(cc) {
 
@@ -18,7 +20,7 @@ class DeleteDomainModelApiController @Inject() (
    * @param dmId ドメインモデルID文字列
    * @return [[NoContent]]
    */
-  def action(@unused bcId: String, dmId: String): Action[AnyContent] = Action {
+  def action(@unused bcId: String, dmId: String): Action[AnyContent] = userAction {
     QueryValidator.sync {
       DomainModelId.validate(dmId)
     } { domainModelId =>

--- a/app/interfaces/api/domainmodel/find/FindDomainModelApiController.scala
+++ b/app/interfaces/api/domainmodel/find/FindDomainModelApiController.scala
@@ -5,12 +5,14 @@ import dev.tchiba.sdmt.core.boundedContext.{BoundedContextAlias, BoundedContextI
 import dev.tchiba.sdmt.core.domainmodel.{DomainModelId, DomainModelRepository, EnglishName}
 import interfaces.api.domainmodel.json.DomainModelResponse
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
 
 final class FindDomainModelApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     domainModelRepository: DomainModelRepository
 ) extends SdmtApiController(cc)
     with EitherExtensions {
@@ -22,7 +24,7 @@ final class FindDomainModelApiController @Inject() (
    * @param boundedContextIdOrAlias 境界づけられたコンテキストID
    * @return ドメインモデル
    */
-  def action(idOrEnglishName: String, boundedContextIdOrAlias: String): Action[AnyContent] = Action {
+  def action(idOrEnglishName: String, boundedContextIdOrAlias: String): Action[AnyContent] = userAction {
 
     val notFoundResponse = notFound(
       code = "sdmt.domainModel.find.notFound",

--- a/app/interfaces/api/domainmodel/list/ListDomainModelsApiController.scala
+++ b/app/interfaces/api/domainmodel/list/ListDomainModelsApiController.scala
@@ -5,12 +5,14 @@ import dev.tchiba.sdmt.core.domainmodel.DomainModelRepository
 import interfaces.api.domainmodel.json.DomainModelResponse
 import interfaces.api.{QueryValidator, SdmtApiController}
 import interfaces.json.CollectionResponse
+import interfaces.security.UserAction
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 import javax.inject.Inject
 
 class ListDomainModelsApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     domainModelRepository: DomainModelRepository
 ) extends SdmtApiController(cc) {
 
@@ -20,7 +22,7 @@ class ListDomainModelsApiController @Inject() (
    * @param bcId 境界づけられたコンテキストID
    * @return 境界づけらえれたコンテキスト一覧
    */
-  def action(bcId: String): Action[AnyContent] = Action {
+  def action(bcId: String): Action[AnyContent] = userAction {
     QueryValidator.sync {
       BoundedContextId.validate(bcId)
     } { boundedContextId =>

--- a/app/interfaces/api/domainmodel/update/UpdateDomainModelApiController.scala
+++ b/app/interfaces/api/domainmodel/update/UpdateDomainModelApiController.scala
@@ -5,6 +5,7 @@ import dev.tchiba.sdmt.core.domainmodel.DomainModelId
 import dev.tchiba.sdmt.usecase.domainmodel.update.{UpdateDomainModelOutput, UpdateDomainModelUseCase}
 import interfaces.api.domainmodel.json.DomainModelResponse
 import interfaces.api.{QueryValidator, SdmtApiController}
+import interfaces.security.UserAction
 import play.api.mvc.{Action, ControllerComponents}
 
 import javax.inject.Inject
@@ -12,12 +13,13 @@ import scala.concurrent.ExecutionContext
 
 class UpdateDomainModelApiController @Inject() (
     cc: ControllerComponents,
+    userAction: UserAction,
     updateDomainModelUseCase: UpdateDomainModelUseCase
 )(implicit ec: ExecutionContext)
     extends SdmtApiController(cc) {
 
   def action(boundedContextId: String, domainModelId: String): Action[UpdateDomainModelRequest] =
-    Action(UpdateDomainModelRequest.validateJson) { implicit request =>
+    userAction(UpdateDomainModelRequest.validateJson) { implicit request =>
       QueryValidator.sync {
         for {
           bcId <- BoundedContextId.validate(boundedContextId)

--- a/front/angular/src/app/models/boundedContext/state/bounded-contexts.service.ts
+++ b/front/angular/src/app/models/boundedContext/state/bounded-contexts.service.ts
@@ -23,10 +23,7 @@ export class BoundedContextsService {
   fetchAll(): void {
     this.http
       .get<ApiCollectionResponse<BoundedContextResponse>>(
-        `${config.apiHost}/bounded-contexts`,
-        {
-          withCredentials: true,
-        }
+        `${config.apiHost}/bounded-contexts`
       )
       .subscribe((res) => {
         const contexts = res.data.map((p) => BoundedContextResponse.convert(p));

--- a/front/angular/src/app/system/default-interceptor.ts
+++ b/front/angular/src/app/system/default-interceptor.ts
@@ -19,7 +19,10 @@ export class DefaultInterceptor implements HttpInterceptor {
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    return next.handle(req).pipe(
+    const withCredentialRequest = req.clone({
+      withCredentials: true,
+    });
+    return next.handle(withCredentialRequest).pipe(
       catchError((e) => {
         console.warn('😈HttpInterceptor😈', e);
         const errRes = e as HttpErrorResponse;

--- a/test/interfaces/api/boundedContext/create/CreateBoundedContextApiControllerTest.scala
+++ b/test/interfaces/api/boundedContext/create/CreateBoundedContextApiControllerTest.scala
@@ -7,10 +7,11 @@ import dev.tchiba.sdmt.core.boundedContext.{
   BoundedContextOverview
 }
 import dev.tchiba.sdmt.usecase.boundedContext.create.{CreateBoundedContextOutput, CreateBoundedContextUseCase}
+import dev.tchiba.test.core.BaseFunTest
+import interfaces.security.StubUserAction
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play._
 import play.api.http.HeaderNames
 import play.api.mvc.{Request, Result, Results}
 import play.api.test.Helpers._
@@ -19,11 +20,13 @@ import play.api.test.{FakeHeaders, FakeRequest}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class CreateBoundedContextApiControllerTest extends PlaySpec with Results with MockitoSugar {
+class CreateBoundedContextApiControllerTest extends BaseFunTest with Results with MockitoSugar {
 
-  "action" when {
-    "successful request has been sent" should {
-      "returns new BoundedContext in json format and OK status" in {
+  val stubUserAction = new StubUserAction
+
+  describe("action") {
+    describe("successful request has been sent") {
+      it("returns new BoundedContext in json format and OK status") {
 
         val mockCreateBoundedContextUseCase = mock[CreateBoundedContextUseCase]
         val newBoundedContext = BoundedContext.create(
@@ -37,6 +40,7 @@ class CreateBoundedContextApiControllerTest extends PlaySpec with Results with M
 
         val controller = new CreateBoundedContextApiController(
           stubControllerComponents(),
+          stubUserAction,
           mockCreateBoundedContextUseCase
         )
 
@@ -53,12 +57,12 @@ class CreateBoundedContextApiControllerTest extends PlaySpec with Results with M
 
         val result: Future[Result] = controller.action().apply(request)
 
-        status(result) mustBe OK
+        assert(status(result) == OK)
       }
     }
 
-    "BoundedContextAlias already exists" should {
-      "return error response in json format and Conflict status" in {
+    describe("BoundedContextAlias already exists") {
+      it("return error response in json format and Conflict status") {
         val mockCreateBoundedContextUseCase = mock[CreateBoundedContextUseCase]
         val conflictBoundedContext = BoundedContext.create(
           BoundedContextAlias("CONFLICT"),
@@ -71,6 +75,7 @@ class CreateBoundedContextApiControllerTest extends PlaySpec with Results with M
 
         val controller = new CreateBoundedContextApiController(
           stubControllerComponents(),
+          stubUserAction,
           mockCreateBoundedContextUseCase
         )
         val request: FakeRequest[CreateBoundedContextRequest] = FakeRequest.apply(
@@ -86,7 +91,7 @@ class CreateBoundedContextApiControllerTest extends PlaySpec with Results with M
 
         val result = controller.action().apply(request)
 
-        status(result) mustBe CONFLICT
+        assert(status(result) == CONFLICT)
       }
     }
   }

--- a/test/interfaces/api/boundedContext/find/FindBoundedContextApiControllerTest.scala
+++ b/test/interfaces/api/boundedContext/find/FindBoundedContextApiControllerTest.scala
@@ -2,6 +2,7 @@ package interfaces.api.boundedContext.find
 
 import dev.tchiba.sdmt.core.boundedContext._
 import interfaces.api.boundedContext.json.BoundedContextResponse
+import interfaces.security.StubUserAction
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -11,6 +12,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status, stubControllerComponents}
 
 class FindBoundedContextApiControllerTest extends PlaySpec with Results with MockitoSugar {
+
+  private val stubUserAction = new StubUserAction
 
   "action" when {
     "requested BoundedContextId is exist" should {
@@ -28,7 +31,7 @@ class FindBoundedContextApiControllerTest extends PlaySpec with Results with Moc
           .thenReturn(Some(existingProject))
 
         val controller =
-          new FindBoundedContextApiController(stubControllerComponents(), mockBoundedContextRepository)
+          new FindBoundedContextApiController(stubControllerComponents(), stubUserAction, mockBoundedContextRepository)
 
         val result = controller.action(boundedContextId.string).apply(FakeRequest())
         status(result) mustEqual OK
@@ -45,7 +48,7 @@ class FindBoundedContextApiControllerTest extends PlaySpec with Results with Moc
           .thenReturn(None)
 
         val controller =
-          new FindBoundedContextApiController(stubControllerComponents(), mockBoundedContextRepository)
+          new FindBoundedContextApiController(stubControllerComponents(), stubUserAction, mockBoundedContextRepository)
 
         val result = controller.action(boundedContextId.string).apply(FakeRequest())
         status(result) mustEqual NOT_FOUND

--- a/test/interfaces/api/domainmodel/create/CreateDomainModelApiControllerTest.scala
+++ b/test/interfaces/api/domainmodel/create/CreateDomainModelApiControllerTest.scala
@@ -8,6 +8,7 @@ import dev.tchiba.sdmt.usecase.domainmodel.create.{
   CreateDomainModelUseCase
 }
 import interfaces.api.domainmodel.json.DomainModelResponse
+import interfaces.security.StubUserAction
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -27,7 +28,7 @@ class CreateDomainModelApiControllerTest extends PlaySpec with MockitoSugar {
     val cc: ControllerComponents                           = Helpers.stubControllerComponents()
     val createDomainModelUseCase: CreateDomainModelUseCase = mock[CreateDomainModelUseCase]
 
-    val controller = new CreateDomainModelApiController(cc, createDomainModelUseCase)
+    val controller = new CreateDomainModelApiController(cc, new StubUserAction, createDomainModelUseCase)
   }
 
   "action" when {

--- a/test/interfaces/api/domainmodel/create/CreateDomainModelRequestTest.scala
+++ b/test/interfaces/api/domainmodel/create/CreateDomainModelRequestTest.scala
@@ -1,42 +1,77 @@
 package interfaces.api.domainmodel.create
 
-import dev.tchiba.sdmt.core.domainmodel.{EnglishName, UbiquitousName}
-import interfaces.json.RequestValidationError
-import org.scalatestplus.play.PlaySpec
+import cats.data.Validated
+import dev.tchiba.test.core.BaseFunTest
 
-class CreateDomainModelRequestTest extends PlaySpec {
+class CreateDomainModelRequestTest extends BaseFunTest {
 
-  "primary constructor" when {
-    "invalid ubiquitousName request" should {
-      "throw RequestValidationError" in {
-        val ubiquitousName = "あ" * 51
-        assertThrows[IllegalArgumentException] {
-          UbiquitousName(ubiquitousName)
+  describe("validateParameters") {
+    describe("ユビキタス名のバリデーション") {
+      it("ユビキタス名が空文字の時、Invalidを返す") {
+        val request = CreateDomainModelRequest(
+          ubiquitousName = "",
+          englishName = "EnglishName",
+          knowledge = "知識"
+        )
+
+        assert(request.validateParameters.isInvalid)
+        inside(request.validateParameters) { case Validated.Invalid(nl) =>
+          assert(nl.head._1 == "ubiquitousName")
         }
+      }
 
-        assertThrows[RequestValidationError] {
-          CreateDomainModelRequest(
-            ubiquitousName,
-            "EnglishName",
-            "Knowledge"
-          )
+      it("ユビキタス名が51文字以下の時、Invalidを返す") {
+        val ubiName = "A" * 51
+        val request = CreateDomainModelRequest(
+          ubiquitousName = ubiName,
+          englishName = "EnglishName",
+          knowledge = "知識"
+        )
+        assert(request.validateParameters.isInvalid)
+        inside(request.validateParameters) { case Validated.Invalid(nl) =>
+          assert(nl.head._1 == "ubiquitousName")
         }
       }
     }
 
-    "invalid EnglishName request" should {
-      "throw RequestValidationError" in {
-        val englishName = "アイウ"
-        assertThrows[IllegalArgumentException] {
-          EnglishName(englishName)
-        }
+    describe("英語名のバリデーション") {
+      it("英語名に日本語が含まれるとき、Invalidを返す") {
+        val request = CreateDomainModelRequest(
+          ubiquitousName = "ユビキタス名",
+          englishName = "ユビキタス名",
+          knowledge = "知識"
+        )
 
-        assertThrows[RequestValidationError] {
-          CreateDomainModelRequest(
-            "ユビキタス名",
-            englishName,
-            "Knowledge"
-          )
+        assert(request.validateParameters.isInvalid)
+        inside(request.validateParameters) { case Validated.Invalid(nl) =>
+          assert(nl.head._1 == "englishName")
+        }
+      }
+
+      it("英語名が空文字の時、Invalidを返す") {
+        val request = CreateDomainModelRequest(
+          ubiquitousName = "ユビキタス名",
+          englishName = "",
+          knowledge = "知識"
+        )
+
+        assert(request.validateParameters.isInvalid)
+        inside(request.validateParameters) { case Validated.Invalid(nl) =>
+          assert(nl.head._1 == "englishName")
+        }
+      }
+
+      it("英語名が101文字の時、Invalidを返す") {
+        val engName = "A" * 101
+        val request = CreateDomainModelRequest(
+          ubiquitousName = "ユビキタス名",
+          englishName = engName,
+          knowledge = "知識"
+        )
+
+        assert(request.validateParameters.isInvalid)
+        inside(request.validateParameters) { case Validated.Invalid(nl) =>
+          assert(nl.head._1 == "englishName")
         }
       }
     }

--- a/test/interfaces/api/domainmodel/find/FindDomainModelApiControllerTest.scala
+++ b/test/interfaces/api/domainmodel/find/FindDomainModelApiControllerTest.scala
@@ -4,6 +4,7 @@ import dev.tchiba.sdmt.core.boundedContext.{BoundedContextAlias, BoundedContextI
 import dev.tchiba.sdmt.core.domainmodel._
 import dev.tchiba.test.core.BaseFunTest
 import interfaces.api.domainmodel.json.DomainModelResponse
+import interfaces.security.StubUserAction
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status._
@@ -13,6 +14,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status, stubControllerComponents}
 
 class FindDomainModelApiControllerTest extends BaseFunTest with Results with MockitoSugar {
+
+  private val stubUserAction = new StubUserAction
 
   describe("action") {
     describe("リクエストされた英語名と境界づけられたコンテキストのエイリアスが正しく、対象のドメインモデルが存在する場合") {
@@ -30,7 +33,8 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
       when(mockDomainModelRepository.findByEnglishName(EnglishName(englishName), BoundedContextAlias(alias)))
         .thenReturn(Some(domainModel))
 
-      val controller = new FindDomainModelApiController(stubControllerComponents(), mockDomainModelRepository)
+      val controller =
+        new FindDomainModelApiController(stubControllerComponents(), stubUserAction, mockDomainModelRepository)
 
       val result = controller.action(englishName, alias).apply(FakeRequest())
       it("OKを返す") {
@@ -59,8 +63,9 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
           BoundedContextId.fromString(boundedContextIdStr)
         )
       ).thenReturn(Some(domainModel))
-      val controller = new FindDomainModelApiController(stubControllerComponents(), mockDomainModelRepository)
-      val result     = controller.action(englishNameStr, boundedContextIdStr).apply(FakeRequest())
+      val controller =
+        new FindDomainModelApiController(stubControllerComponents(), stubUserAction, mockDomainModelRepository)
+      val result = controller.action(englishNameStr, boundedContextIdStr).apply(FakeRequest())
 
       it("OKを返す") {
         status(result) shouldBe OK
@@ -75,8 +80,9 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
       val englishNameStr                = "DomainModel"
       val badBoundedContextIdOrAliasStr = "アイウエオ"
       val mockDomainModelRepository     = mock[DomainModelRepository]
-      val controller                    = new FindDomainModelApiController(stubControllerComponents(), mockDomainModelRepository)
-      val result                        = controller.action(englishNameStr, badBoundedContextIdOrAliasStr).apply(FakeRequest())
+      val controller =
+        new FindDomainModelApiController(stubControllerComponents(), stubUserAction, mockDomainModelRepository)
+      val result = controller.action(englishNameStr, badBoundedContextIdOrAliasStr).apply(FakeRequest())
       it("BadRequestを返す") {
         status(result) shouldBe BAD_REQUEST
       }
@@ -88,7 +94,7 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
       }
     }
 
-    describe("リクエストされたドメインモデルIDのドメインモデルが存在しする場合") {
+    describe("リクエストされたドメインモデルIDのドメインモデルが存在する場合") {
       val domainModelIdStr = DomainModelId.generate().value.toString
       val domainModel = DomainModel.reconstruct(
         id = DomainModelId.fromString(domainModelIdStr),
@@ -101,8 +107,9 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
       when(mockDomainModelRepository.findById(DomainModelId.fromString(domainModelIdStr)))
         .thenReturn(Some(domainModel))
 
-      val controller = new FindDomainModelApiController(stubControllerComponents(), mockDomainModelRepository)
-      val result     = controller.action(domainModelIdStr, "").apply(FakeRequest())
+      val controller =
+        new FindDomainModelApiController(stubControllerComponents(), stubUserAction, mockDomainModelRepository)
+      val result = controller.action(domainModelIdStr, "").apply(FakeRequest())
       it("OKを返す") {
         status(result) shouldBe OK
       }
@@ -118,8 +125,9 @@ class FindDomainModelApiControllerTest extends BaseFunTest with Results with Moc
       when(mockDomainModelRepository.findById(DomainModelId.fromString(domainModelIdStr)))
         .thenReturn(None)
 
-      val controller = new FindDomainModelApiController(stubControllerComponents(), mockDomainModelRepository)
-      val result     = controller.action(domainModelIdStr, "").apply(FakeRequest())
+      val controller =
+        new FindDomainModelApiController(stubControllerComponents(), stubUserAction, mockDomainModelRepository)
+      val result = controller.action(domainModelIdStr, "").apply(FakeRequest())
 
       it("NotFoundを返す") {
         status(result) shouldBe NOT_FOUND

--- a/test/interfaces/api/domainmodel/update/UpdateDomainModelApiControllerTest.scala
+++ b/test/interfaces/api/domainmodel/update/UpdateDomainModelApiControllerTest.scala
@@ -4,6 +4,7 @@ import dev.tchiba.sdmt.core.boundedContext._
 import dev.tchiba.sdmt.core.domainmodel._
 import dev.tchiba.sdmt.usecase.domainmodel.update.{UpdateDomainModelOutput, UpdateDomainModelUseCase}
 import interfaces.api.domainmodel.json.DomainModelResponse
+import interfaces.security.StubUserAction
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -22,7 +23,7 @@ class UpdateDomainModelApiControllerTest extends PlaySpec with Results with Mock
     val cc: ControllerComponents                           = Helpers.stubControllerComponents()
     val updateDomainModelUseCase: UpdateDomainModelUseCase = mock[UpdateDomainModelUseCase]
 
-    val controller = new UpdateDomainModelApiController(cc, updateDomainModelUseCase)
+    val controller = new UpdateDomainModelApiController(cc, new StubUserAction, updateDomainModelUseCase)
   }
 
   "action" when {

--- a/test/interfaces/security/StubUserAction.scala
+++ b/test/interfaces/security/StubUserAction.scala
@@ -1,0 +1,29 @@
+package interfaces.security
+
+import dev.tchiba.auth.core.user.{User, UserId}
+import dev.tchiba.auth.usecase.user.verify.VerifyUserUseCase
+import dev.tchiba.sub.email.EmailAddress
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.{BodyParsers, Request, Result}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class StubUserAction extends UserAction(StubUserAction.mockBodyParsers, StubUserAction.verifyUserUseCase) {
+  override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
+    val tanaka = User.reconstruct(
+      UserId.generate(),
+      name = Some("田中太郎"),
+      emailAddress = EmailAddress("taro.tanaka@example.com"),
+      avatarUrl = None
+    )
+    val u = UserRequest(tanaka, request)
+    block(u)
+  }
+}
+
+object StubUserAction extends MockitoSugar {
+  private val verifyUserUseCase: VerifyUserUseCase = mock[VerifyUserUseCase]
+
+  private val mockBodyParsers: BodyParsers.Default = mock[BodyParsers.Default]
+}


### PR DESCRIPTION
# Summary

Fixes #151 

各APIで `UserAction` を利用するようにし、未ログイン状態で利用できないようにする。 

# Tests

- [x] 各APIを未ログイン状態で叩き、`Unauthorized` が返ることを確認する
- [x] フロントからログイン状態で各種操作を行い、APIが実行できることを確認する